### PR TITLE
Swap A and B to be the same as the hardware

### DIFF
--- a/driver/gui.go
+++ b/driver/gui.go
@@ -36,9 +36,9 @@ func (lcd *LCD) UpdateInput() bool {
 	// Reference :https://github.com/Humpheh/goboy/blob/master/pkg/gbio/iopixel/pixels.go
 	var keyMap = map[pixelgl.Button]byte{
 		// A button
-		pixelgl.KeyZ: 4,
+		pixelgl.KeyZ: 5,
 		// B button
-		pixelgl.KeyX: 5,
+		pixelgl.KeyX: 4,
 		// SELECT button
 		pixelgl.KeyBackspace: 6,
 		// START button


### PR DESCRIPTION
They are currently set up as a mirror image.
Changing this means that on tetris Z i anti-clockwise and X is clockwise rotation.
On Zelda the left hand (B) equipment is on the left hand button.