### PR TITLE
Graphical and Mbc3 Bug Fixes

### DIFF
--- a/gb/core.go
+++ b/gb/core.go
@@ -471,6 +471,7 @@ func (core *Core) initRom(romPath string) {
 			CurrentROMBank: 1,
 			CurrentRAMBank: 0,
 			RAMBank:        ramData,
+            rtc: make([]byte, 0x10),
 		}
 		core.Cartridge.MBC = MBC
 		core.Cartridge.Props = &CartridgeProps{

--- a/gb/graphics.go
+++ b/gb/graphics.go
@@ -181,7 +181,7 @@ func (core *Core) RenderTiles() {
 	//		the window at upper left, it is then completly covering normal
 	//		background.
 	windowY := core.ReadMemory(0xFF4A)
-	windowX := core.ReadMemory(0xFF4B) - 7
+	windowX := int(core.ReadMemory(0xFF4B)) - 7
 
 	usingWindow := false
 
@@ -237,12 +237,12 @@ func (core *Core) RenderTiles() {
 	// for this scanline
 	for pixel := byte(0); pixel < 160; pixel++ {
 
-		xPos := byte(pixel) + scrollX
+		xPos := int(byte(pixel) + scrollX)
 
 		// translate the current x pos to window space if necessary
 		if usingWindow {
-			if pixel >= windowX {
-				xPos = pixel - windowX
+			if int(pixel) >= windowX {
+				xPos = int(pixel) - windowX
 			}
 		}
 


### PR DESCRIPTION
Bug fixes while testing on Pokemon Gold.
1. Rtc was not initializing on MBC3, added make() to struct initialization.
2. window vs background is on a per pixel basis, not per scanline, by using the windowX Register. This is viewable with the Pokedex in Pokemon Gold, where the left side of the screen uses background and the right side uses window. Fixed by splitting background and window addresses per scanline, then checking if window is used and if the current pixel >= windowX. If you need a save to see behavior, please let me know.